### PR TITLE
Decode typed String dictionaries

### DIFF
--- a/Sources/JSONUtilities/Dictionary+JSONKey.swift
+++ b/Sources/JSONUtilities/Dictionary+JSONKey.swift
@@ -87,7 +87,66 @@ extension Dictionary where Key: StringProtocol {
     return self[keyPath: keyPath] as? [JSONDictionary]
   }
 
-  
+  // MARK: [String: JSONObjectConvertible] type
+
+  /// Decodes a mandatory dictionary
+  public func json<JSONObjectConvertibleType: JSONObjectConvertible>(atKeyPath keyPath: Key) throws -> [String: JSONObjectConvertibleType] {
+
+    let jsonDictionary:JSONDictionary = try json(atKeyPath: keyPath)
+
+    var result: [String: JSONObjectConvertibleType] = [:]
+    for (key, _) in jsonDictionary {
+      result[key] = try jsonDictionary.json(atKeyPath: key) as JSONObjectConvertibleType
+    }
+
+    return result
+  }
+
+  /// Decodes an optional dictionary
+  public func json<JSONObjectConvertibleType: JSONObjectConvertible>(atKeyPath keyPath: Key) -> [String: JSONObjectConvertibleType]? {
+    return try? json(atKeyPath: keyPath) as [String: JSONObjectConvertibleType]
+  }
+
+  // MARK: [String: JSONObjectConvertible] type
+
+  /// Decodes a mandatory dictionary
+  public func json<JSONRawTypeType: JSONRawType>(atKeyPath keyPath: Key) throws -> [String: JSONRawTypeType] {
+
+    let jsonDictionary:JSONDictionary = try json(atKeyPath: keyPath)
+
+    var result: [String: JSONRawTypeType] = [:]
+    for (key, _) in jsonDictionary {
+      result[key] = try jsonDictionary.json(atKeyPath: key) as JSONRawTypeType
+    }
+
+    return result
+  }
+
+  /// Decodes an optional dictionary
+  public func json<JSONRawTypeType: JSONRawType>(atKeyPath keyPath: Key) -> [String: JSONRawTypeType]? {
+    return try? json(atKeyPath: keyPath) as [String: JSONRawTypeType]
+  }
+
+  // MARK: [String: JSONPrimitiveConvertible] type
+
+  /// Decodes a mandatory dictionary
+  public func json<JSONPrimitiveConvertibleType: JSONPrimitiveConvertible>(atKeyPath keyPath: Key) throws -> [String: JSONPrimitiveConvertibleType] {
+
+    let jsonDictionary:JSONDictionary = try json(atKeyPath: keyPath)
+
+    var result: [String: JSONPrimitiveConvertibleType] = [:]
+    for (key, _) in jsonDictionary {
+      result[key] = try jsonDictionary.json(atKeyPath: key) as JSONPrimitiveConvertibleType
+    }
+
+    return result
+  }
+
+  /// Decodes an optional dictionary
+  public func json<JSONPrimitiveConvertibleType: JSONPrimitiveConvertible>(atKeyPath keyPath: Key) -> [String: JSONPrimitiveConvertibleType]? {
+    return try? json(atKeyPath: keyPath) as [String: JSONPrimitiveConvertibleType]
+  }
+
   // MARK: Decodable types
   
   /// Decode a mandatory Decodable object

--- a/Tests/JSONUtilitiesTests/JSONDecodingTests.swift
+++ b/Tests/JSONUtilitiesTests/JSONDecodingTests.swift
@@ -67,7 +67,14 @@ class JSONDecoderTests: XCTestCase {
       XCTAssertNil(mockJSONParent.optionalMissingArrayBool)
       XCTAssertNil(mockJSONParent.optionalMissingWeakDictionaryArrayKey)
       XCTAssertNil(mockJSONParent.optionalMissingArrayCustomJSONObject)
-      
+
+      XCTAssertEqual(mockJSONParent.mandatoryIntDictionary, ["value1": 1, "value2": 2])
+      XCTAssertEqual(mockJSONParent.mandatoryObjectDictionary, ["value1": expectedChild, "value2": expectedChild])
+      XCTAssertEqual(mockJSONParent.mandatoryURLDictionary, ["value1": URL(string: "https://google.com")!, "value2": URL(string: "https://apple.com")!])
+      XCTAssertEqual(mockJSONParent.optionalIntDictionary!, ["value1": 1, "value2": 2])
+      XCTAssertEqual(mockJSONParent.optionalObjectDictionary!, ["value1": expectedChild, "value2": expectedChild])
+      XCTAssertEqual(mockJSONParent.optionalURLDictionary!, ["value1": URL(string: "https://google.com")!, "value2": URL(string: "https://apple.com")!])
+
     } catch let error as DecodingError {
       XCTAssertEqual(error.description, "mandatoryKeyNotFound: stringKey")
     } catch {

--- a/Tests/JSONUtilitiesTests/Mocks/MockParent.swift
+++ b/Tests/JSONUtilitiesTests/Mocks/MockParent.swift
@@ -64,6 +64,13 @@ struct MockParent {
   let optionalMissingArrayBool: [Bool]?
   let optionalMissingWeakDictionaryArrayKey: [JSONDictionary]?
   let optionalMissingArrayCustomJSONObject: [MockChild]?
+
+  let mandatoryIntDictionary: [String: Int]
+  let mandatoryObjectDictionary: [String: MockChild]
+  let mandatoryURLDictionary: [String: URL]
+  let optionalIntDictionary: [String: Int]?
+  let optionalObjectDictionary: [String: MockChild]?
+  let optionalURLDictionary: [String: URL]?
   
   init(jsonDictionary: JSONDictionary) throws {
     mandatoryString = try jsonDictionary.json(atKeyPath: "mandatoryStringKey")
@@ -110,5 +117,13 @@ struct MockParent {
     optionalMissingArrayBool = jsonDictionary.json(atKeyPath: randomKey)
     optionalMissingWeakDictionaryArrayKey = jsonDictionary.json(atKeyPath: randomKey)
     optionalMissingArrayCustomJSONObject = jsonDictionary.json(atKeyPath: randomKey)
+
+    mandatoryIntDictionary = try jsonDictionary.json(atKeyPath: "mandatoryIntDictionary")
+    mandatoryObjectDictionary = try jsonDictionary.json(atKeyPath: "mandatoryObjectDictionary")
+    mandatoryURLDictionary = try jsonDictionary.json(atKeyPath: "mandatoryURLDictionary")
+
+    optionalIntDictionary = jsonDictionary.json(atKeyPath: "mandatoryIntDictionary")
+    optionalObjectDictionary = jsonDictionary.json(atKeyPath: "mandatoryObjectDictionary")
+    optionalURLDictionary = jsonDictionary.json(atKeyPath: "mandatoryURLDictionary")
   }
 }

--- a/Tests/JSONUtilitiesTests/TestFiles/correct.json
+++ b/Tests/JSONUtilitiesTests/TestFiles/correct.json
@@ -36,4 +36,26 @@
     "boolKey" : true
   },
   "mandatoryEnum": "one",
+  "mandatoryIntDictionary" : {
+    "value1": 1,
+    "value2" : 2
+  },
+  "mandatoryObjectDictionary" : {
+    "value1": {
+      "stringKey" : "stringValue",
+      "integerKey" : 1,
+      "doubleKey" : 1.2,
+      "boolKey" : true
+    },
+    "value2" : {
+      "stringKey" : "stringValue",
+      "integerKey" : 1,
+      "doubleKey" : 1.2,
+      "boolKey" : true
+    }
+  },
+  "mandatoryURLDictionary" : {
+    "value1": "https://google.com",
+    "value2" : "https://apple.com"
+  },
 }


### PR DESCRIPTION
This adds support for decoding typed dictionaries with a String key, specifically:
`[String: JSONObjectConvertible]`
`[String: JSONRawType]`
`[String: JSONPrimitiveConvertible]`

Includes optional variants and tests
