### PR TITLE
InvalidItemBehaviour.value and InvalidItemBehaviour.custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 ## 4.0.0
 
 - Decoded typed dictionaries now filter out invalid objects by default instead of failing the whole response. This aligns with the defaults of how arrays are decoded.
-- Typed dictionaries and array functions now allow for either removing invalid items or failing to parse the whole dictionary or array, i.e.
-	- `json(atKeyPath: invalidItemBehaviour:)`, 
-	- The `invalidItemBehaviour` parameter defaults to `.remove`
+- Typed dictionaries and array functions now allow for specifiying the behaviour of when a child item encounters an error. See [InvalidItemBehaviour](Readme.md#InvalidItemBehaviour) for more details. The default is to remove these child items with `.remove`
 - DecodingError has been restructured, so that every error provides:
 	- dictionary
 	- keypath
@@ -17,6 +15,8 @@
 	- incorrectRawRepresentableRawValue
 	- incorrectType
 	- conversionFailure
+
+Thanks to [Yonas Kolb](https://github.com/yonaskolb)
 
 ## 3.2.0
 

--- a/JSONUtilities.xcodeproj/project.pbxproj
+++ b/JSONUtilities.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		4FE3C0531C00EED400607CC4 /* empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 4FE3C04E1C00EED400607CC4 /* empty.json */; };
 		4FE3C0551C00EEE800607CC4 /* JSONDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE3C0541C00EEE800607CC4 /* JSONDecodingTests.swift */; };
 		4FF31F3B1D7CBF8C00C9CCC8 /* Dictionary+KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF31F3A1D7CBF8C00C9CCC8 /* Dictionary+KeyPathTests.swift */; };
+		CC0188FF1EB2288A00D4EA87 /* InvalidItemBehaviour.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0188FE1EB2288A00D4EA87 /* InvalidItemBehaviour.swift */; };
 		CCE82AD11EAA41900035C9F1 /* InvalidItemBehaviourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE82ACF1EAA41450035C9F1 /* InvalidItemBehaviourTests.swift */; };
 		EAD4CA401D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD4CA3F1D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift */; };
 /* End PBXBuildFile section */
@@ -84,6 +85,7 @@
 		4FE3C0541C00EEE800607CC4 /* JSONDecodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecodingTests.swift; sourceTree = "<group>"; };
 		4FE3C05B1C00F05700607CC4 /* JSONFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONFiles.swift; sourceTree = "<group>"; };
 		4FF31F3A1D7CBF8C00C9CCC8 /* Dictionary+KeyPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+KeyPathTests.swift"; sourceTree = "<group>"; };
+		CC0188FE1EB2288A00D4EA87 /* InvalidItemBehaviour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvalidItemBehaviour.swift; sourceTree = "<group>"; };
 		CCE82ACF1EAA41450035C9F1 /* InvalidItemBehaviourTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvalidItemBehaviourTests.swift; sourceTree = "<group>"; };
 		EAD4CA3F1D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+JSONPrimitiveConvertible.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -169,6 +171,7 @@
 				4F037C281D1B406D0075FC5E /* JSONObjectConvertible.swift */,
 				4F037C291D1B406D0075FC5E /* JSONPrimitiveConvertible.swift */,
 				EAD4CA3F1D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift */,
+				CC0188FE1EB2288A00D4EA87 /* InvalidItemBehaviour.swift */,
 			);
 			path = JSONUtilities;
 			sourceTree = "<group>";
@@ -381,6 +384,7 @@
 				4F47CDF91D1B3C4800F95472 /* DecodingError.swift in Sources */,
 				4F037C2B1D1B406D0075FC5E /* JSONPrimitiveConvertible.swift in Sources */,
 				4F47CDF71D1B3C4800F95472 /* Deprecations.swift in Sources */,
+				CC0188FF1EB2288A00D4EA87 /* InvalidItemBehaviour.swift in Sources */,
 				4F037C2A1D1B406D0075FC5E /* JSONObjectConvertible.swift in Sources */,
 				EAD4CA401D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift in Sources */,
 			);

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ When decoding arrays or dictionaries an `invalidItemBehaviour` parameter can be 
 - `.remove` this will simply remove the item from the array or dictionary. This is the default
 - `.fail` if any of the children encounter an error the whole array or dictionary decoding will fail. For optional properties this means the array or dictionary will return nil, and for non optional properties it will throw an error
 - `.value(T)` Provide an alternative value
-- `.custom((DecodingError) throws -> T?)` Calculate an alternative value based on the DecodingError via a closure. This lets you look up information about the error to make an informed decision. If you throw an error (typically the one that is passed) this will have the same behaviour as `.fail`, and if you return nil it will be the same as `.remove`
+- `.custom((DecodingError) -> InvalidItemBehaviour)` Lets you specify the behaviour based on the specific DecodingError
 
 ## Examples of JSON loading
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ e.g. if `MyClass` and `MyStruct` conform to `JSONObjectConvertible` protocol
 - `[String: JSONObjectConvertible]`
 - `[String: JSONPrimitiveConvertible]`
 
-### Notes
+## InvalidItemBehaviour
 
-- When decoding arrays or dictionaries an `invalidItemBehaviour` parameter can be passed which controls what happens when an error occurs while decoding child items
-	- `.remove` this will simply remove the item from the array or dictionary. This is the default
-	- `.fail` if any of the children encounter an error the whole array or dictionary decoding will fail. For optional properties this means the array or dictionary will return nil, and for non optional properties it will throw an error
+When decoding arrays or dictionaries an `invalidItemBehaviour` parameter can be passed which controls what happens when an error occurs while decoding child items
+
+- `.remove` this will simply remove the item from the array or dictionary. This is the default
+- `.fail` if any of the children encounter an error the whole array or dictionary decoding will fail. For optional properties this means the array or dictionary will return nil, and for non optional properties it will throw an error
+- `.value(T)` Provide an alternative value
+- `.calculateValue((DecodingError) -> T)` Calculate an alternative value based on the DecodingError via a closure. This lets you look up information about the error to make an informed decision.
 
 ## Examples of JSON loading
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ When decoding arrays or dictionaries an `invalidItemBehaviour` parameter can be 
 - `.remove` this will simply remove the item from the array or dictionary. This is the default
 - `.fail` if any of the children encounter an error the whole array or dictionary decoding will fail. For optional properties this means the array or dictionary will return nil, and for non optional properties it will throw an error
 - `.value(T)` Provide an alternative value
-- `.calculateValue((DecodingError) -> T)` Calculate an alternative value based on the DecodingError via a closure. This lets you look up information about the error to make an informed decision.
+- `.custom((DecodingError) throws -> T?)` Calculate an alternative value based on the DecodingError via a closure. This lets you look up information about the error to make an informed decision. If you throw an error (typically the one that is passed) this will have the same behaviour as `.fail`, and if you return nil it will be the same as `.remove`
 
 ## Examples of JSON loading
 

--- a/Sources/JSONUtilities/DecodingError.swift
+++ b/Sources/JSONUtilities/DecodingError.swift
@@ -73,7 +73,7 @@ public struct DecodingError: Error, CustomStringConvertible, CustomDebugStringCo
     /// The value has the incorrect type
     case incorrectType = "Incorrect type"
 
-    /// A JSONPrimitiveConvertable failed to convert
+    /// A JSONPrimitiveConvertible failed to convert
     case conversionFailure = "Conversion failure"
 
     public var description: String {

--- a/Sources/JSONUtilities/Dictionary+JSONKey.swift
+++ b/Sources/JSONUtilities/Dictionary+JSONKey.swift
@@ -20,9 +20,11 @@ extension Bool : JSONRawType {}
 ///
 /// - remove: The item is filtered, only valid items are returned
 /// - fail:  The call fails. For non optional properties this will throw an error, and for optional properties nil is returned
-public enum InvalidItemBehaviour {
+public enum InvalidItemBehaviour<T> {
   case remove
   case fail
+  case value(T)
+  case calculateValue((DecodingError) -> T)
 }
 
 // Simple protocol used to extend a JSONDictionary
@@ -53,12 +55,12 @@ extension Dictionary where Key: StringProtocol {
   // MARK: [JSONRawType] type
 
   /// Decode an Array of mandatory JSON raw types
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [T] {
+  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour, decode: getValue)
   }
 
   /// Decode an Array of optional JSON raw types
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [T]? {
+  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
     return try? self.json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
@@ -77,54 +79,54 @@ extension Dictionary where Key: StringProtocol {
   // MARK: [[String: Any]] type
 
   /// Decodes as a raw dictionary array with a mandatory key
-  public func json(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [JSONDictionary] {
+  public func json(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<JSONDictionary> = .remove) throws -> [JSONDictionary] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour, decode: getValue)
   }
 
   /// Decodes as a raw ictionary array with an optional key
-  public func json(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [JSONDictionary]? {
+  public func json(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<JSONDictionary> = .remove) -> [JSONDictionary]? {
     return try? self.json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
   // MARK: [String: JSONObjectConvertible] type
 
   /// Decodes a mandatory dictionary
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [String: T] {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
     return try decodeDictionary(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { jsonDictionary, key in
       return try jsonDictionary.json(atKeyPath: key) as T
     }
   }
 
   /// Decodes an optional dictionary
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [String: T]? {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) as [String: T]
   }
 
   // MARK: [String: JSONRawType] type
 
   /// Decodes a mandatory dictionary
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [String: T] {
+  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
     return try decodeDictionary(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { jsonDictionary, key in
       return try jsonDictionary.json(atKeyPath: key) as T
     }
   }
 
   /// Decodes an optional dictionary
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [String: T]? {
+  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) as [String: T]
   }
 
   // MARK: [String: JSONPrimitiveConvertible] type
 
   /// Decodes a mandatory dictionary
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [String: T] {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
     return try decodeDictionary(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { jsonDictionary, key in
       return try jsonDictionary.json(atKeyPath: key) as T
     }
   }
 
   /// Decodes an optional dictionary
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [String: T]? {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) as [String: T]
   }
 
@@ -143,7 +145,7 @@ extension Dictionary where Key: StringProtocol {
   // MARK: [Decodable] types
 
   /// Decode an Array of mandatory Decodable objects
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [T] {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { keyPath, jsonArray, value in
       let jsonDictionary: JSONDictionary = try getValue(atKeyPath: keyPath, array: jsonArray, value: value)
       return try T(jsonDictionary: jsonDictionary)
@@ -151,7 +153,7 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Decode an Array of optional Decodable objects
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [T]? {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
@@ -176,7 +178,7 @@ extension Dictionary where Key: StringProtocol {
   // MARK: [RawRepresentable] type
 
   /// Decode an array of custom RawRepresentable types with a mandatory key
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [T] where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] where T.RawValue:JSONRawType {
 
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { keyPath, jsonArray, value in
       let rawValue: T.RawValue = try getValue(atKeyPath: keyPath, array: jsonArray, value: value)
@@ -189,7 +191,7 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Optionally decode an array of RawRepresentable types with a mandatory key
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [T]? where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? where T.RawValue:JSONRawType {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
@@ -214,7 +216,7 @@ extension Dictionary where Key: StringProtocol {
   // MARK: [JSONPrimitiveConvertible] type
 
   /// Decode an array of custom raw types with a mandatory key
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) throws -> [T] {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { keyPath, jsonArray, value in
       let jsonValue: T.JSONType = try getValue(atKeyPath: keyPath, array: jsonArray, value: value)
 
@@ -226,7 +228,7 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Optionally decode an array custom raw types with a mandatory key
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove) -> [T]? {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
@@ -261,7 +263,7 @@ extension Dictionary where Key: StringProtocol {
 
   // MARK: Dictionary decoding
 
-  fileprivate func decodeDictionary<T>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove, decode: (JSONDictionary, String) throws -> T) throws -> [String: T] {
+  fileprivate func decodeDictionary<T>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove, decode: (JSONDictionary, String) throws -> T) throws -> [String: T] {
     let jsonDictionary: JSONDictionary = try json(atKeyPath: keyPath)
 
     var dictionary: [String: T] = [:]
@@ -274,6 +276,18 @@ extension Dictionary where Key: StringProtocol {
         }
       case .fail:
         dictionary[key] = try decode(jsonDictionary, key)
+      case .value(let value):
+        do {
+          dictionary[key] = try decode(jsonDictionary, key)
+        } catch {
+          dictionary[key] = value
+        }
+      case .calculateValue(let getValue):
+        do {
+          dictionary[key] = try decode(jsonDictionary, key)
+        } catch let error as DecodingError {
+          dictionary[key] = getValue(error)
+        }
       }
     }
 
@@ -283,7 +297,7 @@ extension Dictionary where Key: StringProtocol {
   // MARK: Array decoding
 
   //swiftlint:disable:next large_tuple
-  fileprivate func decodeArray<T>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour = .remove, decode: (Key, JSONArray, Any) throws -> T) throws -> [T] {
+  fileprivate func decodeArray<T>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove, decode: (Key, JSONArray, Any) throws -> T) throws -> [T] {
     let jsonArray = try JSONArrayForKey(atKeyPath: keyPath)
 
     return try jsonArray.flatMap {
@@ -292,6 +306,18 @@ extension Dictionary where Key: StringProtocol {
         return try? decode(keyPath, jsonArray, $0)
       case .fail:
         return try decode(keyPath, jsonArray, $0)
+      case .value(let value):
+        do {
+          return try decode(keyPath, jsonArray, $0)
+        } catch {
+          return value
+        }
+      case .calculateValue(let getValue):
+        do {
+          return try decode(keyPath, jsonArray, $0)
+        } catch let error as DecodingError {
+          return getValue(error)
+        }
       }
     }
   }

--- a/Sources/JSONUtilities/Dictionary+JSONKey.swift
+++ b/Sources/JSONUtilities/Dictionary+JSONKey.swift
@@ -16,17 +16,6 @@ extension Float : JSONRawType {}
 extension String : JSONRawType {}
 extension Bool : JSONRawType {}
 
-/// The behaviour of what should be done when an invalid JSON object or primitive is found
-///
-/// - remove: The item is filtered, only valid items are returned
-/// - fail:  The call fails. For non optional properties this will throw an error, and for optional properties nil is returned
-public enum InvalidItemBehaviour<T> {
-  case remove
-  case fail
-  case value(T)
-  case custom((DecodingError) throws -> T?)
-}
-
 // Simple protocol used to extend a JSONDictionary
 public protocol StringProtocol {
   func components(separatedBy: String) -> [String]

--- a/Sources/JSONUtilities/Dictionary+JSONKey.swift
+++ b/Sources/JSONUtilities/Dictionary+JSONKey.swift
@@ -24,7 +24,7 @@ public enum InvalidItemBehaviour<T> {
   case remove
   case fail
   case value(T)
-  case calculateValue((DecodingError) -> T)
+  case custom((DecodingError) throws -> T?)
 }
 
 // Simple protocol used to extend a JSONDictionary
@@ -282,11 +282,11 @@ extension Dictionary where Key: StringProtocol {
         } catch {
           dictionary[key] = value
         }
-      case .calculateValue(let getValue):
+      case .custom(let getValue):
         do {
           dictionary[key] = try decode(jsonDictionary, key)
         } catch let error as DecodingError {
-          dictionary[key] = getValue(error)
+          dictionary[key] = try getValue(error)
         }
       }
     }
@@ -312,11 +312,11 @@ extension Dictionary where Key: StringProtocol {
         } catch {
           return value
         }
-      case .calculateValue(let getValue):
+      case .custom(let getValue):
         do {
           return try decode(keyPath, jsonArray, $0)
         } catch let error as DecodingError {
-          return getValue(error)
+          return try getValue(error)
         }
       }
     }

--- a/Sources/JSONUtilities/InvalidItemBehaviour.swift
+++ b/Sources/JSONUtilities/InvalidItemBehaviour.swift
@@ -1,0 +1,20 @@
+//
+//  InvalidItemBehaviour.swift
+//  JSONUtilities
+//
+//  Created by Yonas Kolb on 27/4/17.
+//  Copyright © 2017 Luciano Marisi. All rights reserved.
+//
+
+import Foundation
+
+/// The behaviour of what should be done when an invalid JSON object or primitive is found
+///
+/// - remove: The item is filtered, only valid items are returned
+/// - fail:  The call fails. For non optional properties this will throw an error, and for optional properties nil is returned
+public enum InvalidItemBehaviour<T> {
+  case remove
+  case fail
+  case value(T)
+  case custom((DecodingError) throws -> T?)
+}

--- a/Sources/JSONUtilities/InvalidItemBehaviour.swift
+++ b/Sources/JSONUtilities/InvalidItemBehaviour.swift
@@ -17,4 +17,29 @@ public enum InvalidItemBehaviour<T> {
   case fail
   case value(T)
   case custom((DecodingError) throws -> T?)
+
+  func decodeItem(decode: () throws -> T) throws -> T? {
+    switch self {
+    case .remove:
+      do {
+         return try decode()
+      } catch {
+        return nil
+      }
+    case .fail:
+      return try decode()
+    case .value(let value):
+      do {
+        return try decode()
+      } catch {
+        return value
+      }
+    case .custom(let getValue):
+      do {
+        return try decode()
+      } catch let error as DecodingError {
+        return try getValue(error)
+      }
+    }
+  }
 }

--- a/Tests/JSONUtilitiesTests/Helpers/XCTestCase+Additions.swift
+++ b/Tests/JSONUtilitiesTests/Helpers/XCTestCase+Additions.swift
@@ -15,6 +15,14 @@ extension XCTestCase {
     return Bundle(for: type(of: self))
   }
 
+  func expectNoError(decode: () throws -> Void) {
+    do {
+      try decode()
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
   func expectDecodingError(reason: DecodingError.Reason, keyPath: String, decode: () throws -> Void) {
     do {
       try decode()

--- a/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
+++ b/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
@@ -189,4 +189,192 @@ class InvalidItemBehaviourTests: XCTestCase {
     }
   }
 
+  // MARK: Dictionary InvalidItemBehaviour.value
+
+  func test_stringJSONRawTypeDictionary_setsValue_invalidItemBehaviourIsValue() {
+    let dictionary = [
+      "key": [
+        "key1": "value1",
+        "key2": 2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String: String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value("default"))
+      XCTAssert(decodedDictionary["key2"] == "default")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsValue() {
+    let dictionary = [
+      "key": [
+        "key1": "www.google.com",
+        "key2": 2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String: URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(URL(string: "test.com")!))
+      XCTAssert(decodedDictionary["key2"]?.absoluteString == "test.com")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONObjectConvertibleDictionaryy_setsValue_invalidItemBehaviourIsValue() {
+    let dictionary = [
+      "key": [
+        "key1": ["name": "john"],
+        "key2": 2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String: MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(MockSimpleChild(name: "default")))
+      XCTAssert(decodedDictionary["key2"]?.name == "default")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  // MARK: Dictionary InvalidItemBehaviour.calculateValue
+
+  func test_stringJSONRawTypeDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
+    let dictionary = [
+      "key": [
+        "key1": "value1",
+        "key2": 2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String: String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({"\($0.value)"}))
+      XCTAssert(decodedDictionary["key2"] == "2")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
+    let dictionary = [
+      "key": [
+        "key1": "www.google.com",
+        "key2": 2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String: URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
+      XCTAssert(decodedDictionary["key2"]?.absoluteString == "2")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONObjectConvertibleDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
+    let dictionary = [
+      "key": [
+        "key1": ["name": "john"],
+        "key2": 2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String: MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
+      XCTAssert(decodedDictionary["key2"]?.name == "2")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  // MARK: Array InvalidItemBehaviour.value
+
+  func test_stringJSONRawTypeArray_setsValue_invalidItemBehaviourIsValue() {
+    let dictionary = [
+      "key": [
+        "value1",
+        2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value("default"))
+      XCTAssert(decodedDictionary.last == "default")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsValue() {
+    let dictionary = [
+      "key": [
+        "www.google.com",
+        2
+      ]
+    ]
+    do {
+      let decodedDictionary: [URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(URL(string: "test.com")!))
+      XCTAssert(decodedDictionary.last?.absoluteString == "test.com")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONObjectConvertibleArray_setsValue_invalidItemBehaviourIsValue() {
+    let dictionary = [
+      "key": [
+        ["name": "john"],
+        2
+      ]
+    ]
+    do {
+      let decodedDictionary: [MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(MockSimpleChild(name: "default")))
+      XCTAssert(decodedDictionary.last?.name == "default")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  // MARK: Array InvalidItemBehaviour.calculateValue
+
+  func test_stringJSONRawTypeArray_setsValue_invalidItemBehaviourIsCalculateValue() {
+    let dictionary = [
+      "key": [
+        "value1",
+        2
+      ]
+    ]
+    do {
+      let decodedDictionary: [String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({"\($0.value)"}))
+      XCTAssert(decodedDictionary.last == "2")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsCalculateValue() {
+    let dictionary = [
+      "key": [
+        "www.google.com",
+        2
+      ]
+    ]
+    do {
+      let decodedDictionary: [URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
+      XCTAssert(decodedDictionary.last?.absoluteString == "2")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
+  func test_stringJSONObjectConvertibleArray_setsValue_invalidItemBehaviourIsCalculateValue() {
+    let dictionary = [
+      "key": [
+        ["name": "john"],
+        2
+      ]
+    ]
+    do {
+      let decodedDictionary: [MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
+      XCTAssert(decodedDictionary.last?.name == "2")
+    } catch {
+      XCTFail("Should not throw error")
+    }
+  }
+
 }

--- a/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
+++ b/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
@@ -166,25 +166,25 @@ class InvalidItemBehaviourTests: XCTestCase {
     }
   }
 
-  // MARK: Dictionary InvalidItemBehaviour.calculateValue
+  // MARK: Dictionary InvalidItemBehaviour.custom
 
-  func test_stringJSONRawTypeDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
+  func test_stringJSONRawTypeDictionary_setsValue_invalidItemBehaviourIsCustom() {
     expectNoError {
-      let decodedDictionary: [String: String] = try dictionaryString.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({"\($0.value)"}))
+      let decodedDictionary: [String: String] = try dictionaryString.json(atKeyPath: key, invalidItemBehaviour: .custom({"\($0.value)"}))
       XCTAssert(decodedDictionary["key2"] == "2")
     }
   }
 
-  func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
+  func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsCustom() {
     expectNoError {
-      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
+      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .custom({URL(string: "\($0.value)")!}))
       XCTAssert(decodedDictionary["key2"]?.absoluteString == "2")
     }
   }
 
   func test_stringJSONObjectConvertibleDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
     expectNoError {
-      let decodedDictionary: [String: MockSimpleChild] = try dictionaryMockChild.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
+      let decodedDictionary: [String: MockSimpleChild] = try dictionaryMockChild.json(atKeyPath: key, invalidItemBehaviour: .custom({MockSimpleChild(name: "\($0.value)") }))
       XCTAssert(decodedDictionary["key2"]?.name == "2")
     }
   }
@@ -212,26 +212,41 @@ class InvalidItemBehaviourTests: XCTestCase {
     }
   }
 
-  // MARK: Array InvalidItemBehaviour.calculateValue
+  // MARK: Array InvalidItemBehaviour.custom
 
-  func test_stringJSONRawTypeArray_setsValue_invalidItemBehaviourIsCalculateValue() {
+  func test_stringJSONRawTypeArray_setsValue_invalidItemBehaviourIsCustom() {
     expectNoError {
-      let decodedDictionary: [String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({"\($0.value)"}))
+      let decodedDictionary: [String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .custom({"\($0.value)"}))
       XCTAssert(decodedDictionary.last == "2")
     }
   }
 
-  func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsCalculateValue() {
+  func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsCustom() {
     expectNoError {
-      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
+      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .custom({URL(string: "\($0.value)")!}))
       XCTAssert(decodedDictionary.last?.absoluteString == "2")
     }
   }
 
-  func test_stringJSONObjectConvertibleArray_setsValue_invalidItemBehaviourIsCalculateValue() {
+  func test_stringJSONObjectConvertibleArray_setsValue_invalidItemBehaviourIsCustom() {
     expectNoError {
-      let decodedDictionary: [MockSimpleChild] = try arrayMockChild.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
+      let decodedDictionary: [MockSimpleChild] = try arrayMockChild.json(atKeyPath: key, invalidItemBehaviour: .custom({MockSimpleChild(name: "\($0.value)") }))
       XCTAssert(decodedDictionary.last?.name == "2")
+    }
+  }
+
+  // MARK: InvalidItemBehaviour.custom
+
+  func test_invalidItemBehaviourIsCustom_removesNil() {
+    expectNoError {
+      let array: [String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .custom({ _ in nil }))
+      XCTAssert(array.count == 1)
+    }
+  }
+
+  func test_invalidItemBehaviourIsCustom_throws() {
+    expectDecodingError(reason: .incorrectType, keyPath: key) {
+      let _: [String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .custom({ throw $0 }))
     }
   }
 

--- a/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
+++ b/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
@@ -13,367 +13,225 @@ private let randomKey = "aaaaaaa"
 
 class InvalidItemBehaviourTests: XCTestCase {
 
+  let key = "key"
+
+  let dictionaryString = [
+    "key": [
+      "key1": "value1",
+      "key2": 2
+    ]
+  ]
+
+  let dictionaryConvertable = [
+    "key": [
+      "key1": "www.google.com",
+      "key2": 2
+    ]
+  ]
+
+  let dictionaryMockChild = [
+    "key": [
+      "key1": ["name": "john"],
+      "key2": 2
+    ]
+  ]
+
+  let arrayString = [
+    "key": [
+      "value1",
+      2
+    ]
+  ]
+
+  let arrayConvertable = [
+    "key": [
+      "www.google.com",
+      2
+    ]
+  ]
+
+  let arrayMockChild = [
+    "key": [
+      ["name": "john"],
+      2
+    ]
+  ]
+
   // MARK: Dictionary InvalidItemBehaviour.fail
 
   func test_stringJSONRawTypeDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
-    let dictionary = [
-      "key": [
-        "key1": "value1",
-        "key2": 2
-      ]
-    ]
-
     expectDecodingError(reason: .incorrectType, keyPath: "key2") {
-      let _ : [String: String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .fail)
+      let _ : [String: String] = try dictionaryString.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
   func test_stringJSONPrimitiveConvertibleDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
-    let dictionary = [
-      "key": [
-        "key1": "www.google.com",
-        "key2": 2
-      ]
-    ]
-
     expectDecodingError(reason: .incorrectType, keyPath: "key2") {
-      let _ : [String: URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .fail)
+      let _ : [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
   func test_stringJSONObjectConvertibleDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
-    let dictionary = [
-      "key": [
-        "key1": ["name": "john"],
-        "key2": 2
-      ]
-    ]
-
     expectDecodingError(reason: .incorrectType, keyPath: "key2") {
-      let _ : [String: MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .fail)
+      let _ : [String: MockSimpleChild] = try dictionaryMockChild.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
   // MARK: Dictionary InvalidItemBehaviour.remove
 
   func test_stringJSONRawTypeDictionary_removesInvalidObjects_invalidItemBehaviourIsRemove() {
-    let dictionary = [
-      "key": [
-        "key1": "value1",
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .remove)
+    expectNoError {
+      let decodedDictionary: [String: String] = try dictionaryString.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONPrimitiveConvertibleDictionary_removesInvalidObjects_invalidItemBehaviourIsRemove() {
-    let dictionary = [
-      "key": [
-        "key1": "www.google.com",
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .remove)
+    expectNoError {
+      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONObjectConvertibleDictionary_removesInvalidObjects_invalidItemBehaviourIsRemove() {
-    let dictionary = [
-      "key": [
-        "key1": ["name": "john"],
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .remove)
+    expectNoError {
+      let decodedDictionary: [String: MockSimpleChild] = try dictionaryMockChild.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   // MARK: Array InvalidItemBehaviour.fail
 
   func test_stringJSONRawTypeArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
-    let dictionary = [
-      "key": [
-        "value1",
-        2
-      ]
-    ]
-
-    expectDecodingError(reason: .incorrectType, keyPath: "key") {
-      let _ : [String: String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .fail)
+    expectDecodingError(reason: .incorrectType, keyPath: key) {
+      let _ : [String: String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
   func test_stringJSONPrimitiveConvertibleArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
-    let dictionary = [
-      "key": [
-        "www.google.com",
-        2
-      ]
-    ]
-
-    expectDecodingError(reason: .incorrectType, keyPath: "key") {
-      let _ : [URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .fail)
+    expectDecodingError(reason: .incorrectType, keyPath: key) {
+      let _ : [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
   func test_stringJSONObjectConvertibleArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
-    let dictionary = [
-      "key": [
-        ["name": "john"],
-        2
-      ]
-    ]
-
-    expectDecodingError(reason: .incorrectType, keyPath: "key") {
-      let _ : [MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .fail)
+    expectDecodingError(reason: .incorrectType, keyPath: key) {
+      let _ : [MockSimpleChild] = try arrayMockChild.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
   // MARK: Array InvalidItemBehaviour.remove
 
   func test_stringJSONRawTypeArray_removesInvalidObjects_invalidItemBehaviourIsRemove() {
-    let dictionary = [
-      "key": [
-        "value1",
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .remove)
+   expectNoError {
+      let decodedDictionary: [String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONPrimitiveConvertibleArray_removesInvalidObjects_invalidItemBehaviourIsRemove() {
-    let dictionary = [
-      "key": [
-        "www.google.com",
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .remove)
+   expectNoError {
+      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONObjectConvertibleArray_removesInvalidObjects_invalidItemBehaviourIsRemove() {
-    let dictionary = [
-      "key": [
-        ["name": "john"],
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .remove)
+    expectNoError {
+      let decodedDictionary: [MockSimpleChild] = try arrayMockChild.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   // MARK: Dictionary InvalidItemBehaviour.value
 
   func test_stringJSONRawTypeDictionary_setsValue_invalidItemBehaviourIsValue() {
-    let dictionary = [
-      "key": [
-        "key1": "value1",
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value("default"))
+    expectNoError {
+      let decodedDictionary: [String: String] = try dictionaryString.json(atKeyPath: key, invalidItemBehaviour: .value("default"))
       XCTAssert(decodedDictionary["key2"] == "default")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsValue() {
-    let dictionary = [
-      "key": [
-        "key1": "www.google.com",
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(URL(string: "test.com")!))
+    expectNoError {
+      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .value(URL(string: "test.com")!))
       XCTAssert(decodedDictionary["key2"]?.absoluteString == "test.com")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONObjectConvertibleDictionaryy_setsValue_invalidItemBehaviourIsValue() {
-    let dictionary = [
-      "key": [
-        "key1": ["name": "john"],
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(MockSimpleChild(name: "default")))
+    expectNoError {
+      let decodedDictionary: [String: MockSimpleChild] = try dictionaryMockChild.json(atKeyPath: key, invalidItemBehaviour: .value(MockSimpleChild(name: "default")))
       XCTAssert(decodedDictionary["key2"]?.name == "default")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   // MARK: Dictionary InvalidItemBehaviour.calculateValue
 
   func test_stringJSONRawTypeDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
-    let dictionary = [
-      "key": [
-        "key1": "value1",
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({"\($0.value)"}))
+    expectNoError {
+      let decodedDictionary: [String: String] = try dictionaryString.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({"\($0.value)"}))
       XCTAssert(decodedDictionary["key2"] == "2")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
-    let dictionary = [
-      "key": [
-        "key1": "www.google.com",
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
+    expectNoError {
+      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
       XCTAssert(decodedDictionary["key2"]?.absoluteString == "2")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONObjectConvertibleDictionary_setsValue_invalidItemBehaviourIsCalculateValue() {
-    let dictionary = [
-      "key": [
-        "key1": ["name": "john"],
-        "key2": 2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String: MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
+    expectNoError {
+      let decodedDictionary: [String: MockSimpleChild] = try dictionaryMockChild.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
       XCTAssert(decodedDictionary["key2"]?.name == "2")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   // MARK: Array InvalidItemBehaviour.value
 
   func test_stringJSONRawTypeArray_setsValue_invalidItemBehaviourIsValue() {
-    let dictionary = [
-      "key": [
-        "value1",
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value("default"))
+    expectNoError {
+      let decodedDictionary: [String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .value("default"))
       XCTAssert(decodedDictionary.last == "default")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsValue() {
-    let dictionary = [
-      "key": [
-        "www.google.com",
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(URL(string: "test.com")!))
+    expectNoError {
+      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .value(URL(string: "test.com")!))
       XCTAssert(decodedDictionary.last?.absoluteString == "test.com")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONObjectConvertibleArray_setsValue_invalidItemBehaviourIsValue() {
-    let dictionary = [
-      "key": [
-        ["name": "john"],
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .value(MockSimpleChild(name: "default")))
+    expectNoError {
+      let decodedDictionary: [MockSimpleChild] = try arrayMockChild.json(atKeyPath: key, invalidItemBehaviour: .value(MockSimpleChild(name: "default")))
       XCTAssert(decodedDictionary.last?.name == "default")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   // MARK: Array InvalidItemBehaviour.calculateValue
 
   func test_stringJSONRawTypeArray_setsValue_invalidItemBehaviourIsCalculateValue() {
-    let dictionary = [
-      "key": [
-        "value1",
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [String] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({"\($0.value)"}))
+    expectNoError {
+      let decodedDictionary: [String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({"\($0.value)"}))
       XCTAssert(decodedDictionary.last == "2")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsCalculateValue() {
-    let dictionary = [
-      "key": [
-        "www.google.com",
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [URL] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
+    expectNoError {
+      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({URL(string: "\($0.value)")!}))
       XCTAssert(decodedDictionary.last?.absoluteString == "2")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 
   func test_stringJSONObjectConvertibleArray_setsValue_invalidItemBehaviourIsCalculateValue() {
-    let dictionary = [
-      "key": [
-        ["name": "john"],
-        2
-      ]
-    ]
-    do {
-      let decodedDictionary: [MockSimpleChild] = try dictionary.json(atKeyPath: "key", invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
+    expectNoError {
+      let decodedDictionary: [MockSimpleChild] = try arrayMockChild.json(atKeyPath: key, invalidItemBehaviour: .calculateValue({MockSimpleChild(name: "\($0.value)") }))
       XCTAssert(decodedDictionary.last?.name == "2")
-    } catch {
-      XCTFail("Should not throw error")
     }
   }
 

--- a/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
+++ b/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
@@ -22,7 +22,7 @@ class InvalidItemBehaviourTests: XCTestCase {
     ]
   ]
 
-  let dictionaryConvertable = [
+  let dictionaryConvertible = [
     "key": [
       "key1": "www.google.com",
       "key2": 2
@@ -43,7 +43,7 @@ class InvalidItemBehaviourTests: XCTestCase {
     ]
   ]
 
-  let arrayConvertable = [
+  let arrayConvertible = [
     "key": [
       "www.google.com",
       2
@@ -67,7 +67,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
     expectDecodingError(reason: .incorrectType, keyPath: "key2") {
-      let _ : [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .fail)
+      let _ : [String: URL] = try dictionaryConvertible.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
@@ -88,7 +88,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleDictionary_removesInvalidObjects_invalidItemBehaviourIsRemove() {
     expectNoError {
-      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .remove)
+      let decodedDictionary: [String: URL] = try dictionaryConvertible.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
     }
   }
@@ -110,7 +110,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
     expectDecodingError(reason: .incorrectType, keyPath: key) {
-      let _ : [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .fail)
+      let _ : [URL] = try arrayConvertible.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
@@ -131,7 +131,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleArray_removesInvalidObjects_invalidItemBehaviourIsRemove() {
    expectNoError {
-      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .remove)
+      let decodedDictionary: [URL] = try arrayConvertible.json(atKeyPath: key, invalidItemBehaviour: .remove)
       XCTAssert(decodedDictionary.count == 1)
     }
   }
@@ -154,7 +154,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsValue() {
     expectNoError {
-      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .value(URL(string: "test.com")!))
+      let decodedDictionary: [String: URL] = try dictionaryConvertible.json(atKeyPath: key, invalidItemBehaviour: .value(URL(string: "test.com")!))
       XCTAssert(decodedDictionary["key2"]?.absoluteString == "test.com")
     }
   }
@@ -177,7 +177,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleDictionary_setsValue_invalidItemBehaviourIsCustom() {
     expectNoError {
-      let decodedDictionary: [String: URL] = try dictionaryConvertable.json(atKeyPath: key, invalidItemBehaviour: .custom({URL(string: "\($0.value)")!}))
+      let decodedDictionary: [String: URL] = try dictionaryConvertible.json(atKeyPath: key, invalidItemBehaviour: .custom({URL(string: "\($0.value)")!}))
       XCTAssert(decodedDictionary["key2"]?.absoluteString == "2")
     }
   }
@@ -200,7 +200,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsValue() {
     expectNoError {
-      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .value(URL(string: "test.com")!))
+      let decodedDictionary: [URL] = try arrayConvertible.json(atKeyPath: key, invalidItemBehaviour: .value(URL(string: "test.com")!))
       XCTAssert(decodedDictionary.last?.absoluteString == "test.com")
     }
   }
@@ -223,7 +223,7 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   func test_stringJSONPrimitiveConvertibleArray_setsValue_invalidItemBehaviourIsCustom() {
     expectNoError {
-      let decodedDictionary: [URL] = try arrayConvertable.json(atKeyPath: key, invalidItemBehaviour: .custom({URL(string: "\($0.value)")!}))
+      let decodedDictionary: [URL] = try arrayConvertible.json(atKeyPath: key, invalidItemBehaviour: .custom({URL(string: "\($0.value)")!}))
       XCTAssert(decodedDictionary.last?.absoluteString == "2")
     }
   }

--- a/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
+++ b/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
@@ -59,19 +59,19 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   // MARK: Dictionary InvalidItemBehaviour.fail
 
-  func test_stringJSONRawTypeDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
+  func test_stringJSONRawTypeDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsFail() {
     expectDecodingError(reason: .incorrectType, keyPath: "key2") {
       let _ : [String: String] = try dictionaryString.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
-  func test_stringJSONPrimitiveConvertibleDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
+  func test_stringJSONPrimitiveConvertibleDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsFail() {
     expectDecodingError(reason: .incorrectType, keyPath: "key2") {
       let _ : [String: URL] = try dictionaryConvertible.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
-  func test_stringJSONObjectConvertibleDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
+  func test_stringJSONObjectConvertibleDictionaryFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsFail() {
     expectDecodingError(reason: .incorrectType, keyPath: "key2") {
       let _ : [String: MockSimpleChild] = try dictionaryMockChild.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
@@ -102,19 +102,19 @@ class InvalidItemBehaviourTests: XCTestCase {
 
   // MARK: Array InvalidItemBehaviour.fail
 
-  func test_stringJSONRawTypeArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
+  func test_stringJSONRawTypeArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsFail() {
     expectDecodingError(reason: .incorrectType, keyPath: key) {
       let _ : [String: String] = try arrayString.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
-  func test_stringJSONPrimitiveConvertibleArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
+  func test_stringJSONPrimitiveConvertibleArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsFail() {
     expectDecodingError(reason: .incorrectType, keyPath: key) {
       let _ : [URL] = try arrayConvertible.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }
   }
 
-  func test_stringJSONObjectConvertibleArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsThrow() {
+  func test_stringJSONObjectConvertibleArrayFails_whenThereAreInvalidObjects_and_invalidItemBehaviourIsFail() {
     expectDecodingError(reason: .incorrectType, keyPath: key) {
       let _ : [MockSimpleChild] = try arrayMockChild.json(atKeyPath: key, invalidItemBehaviour: .fail)
     }


### PR DESCRIPTION
This adds 2 new InvalidItemBehaviours including tests:
- `.value(T)`
- `.custom((DecodingError) -> InvalidItemBehaviour)`