### PR TITLE
Change keyPath to KeyPath enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 	- incorrectType
 	- conversionFailure
 - `[String: RawRepresentable]` can be now be decoded
+- KeyPath has changed to enum with .key(String) and .keyPath([String]) cases. It can still be initialized with a string literal, with `.` representing keyPaths.
+- Array indexes can now also be pathed into using an int in the keyPath, e.g: `myArray.2.valueInArrayItem`
 
 Thanks to [Yonas Kolb](https://github.com/yonaskolb)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `[String: RawRepresentable]` can be now be decoded
 - KeyPath has changed to enum with .key(String) and .keyPath([String]) cases. It can still be initialized with a string literal, with `.` representing keyPaths.
 - Array indexes can now also be pathed into using an int in the keyPath, e.g: `myArray.2.valueInArrayItem`
-- Decoding Dictionaries can now have any key that conforms to JSONKey (which String does by default). So you can for example have enums as the key in a dictionary. Just make your Enum conform to JSONKey. If it is a String RawRepresentable, conformance is supplied automatically. So now you can do: 
+- Decoding Dictionaries can now have any key that conforms to JSONKey (which String does by default). So you can for example have enums as the key in a dictionary. Just make your Enum conform to JSONKey. So now you can do: 
 `let counts: [MyEnum: Int] = try jsonDictionary.json(keyKeyPath: "counts")`
 
 Thanks to [Yonas Kolb](https://github.com/yonaskolb)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - `[String: RawRepresentable]` can be now be decoded
 - KeyPath has changed to enum with .key(String) and .keyPath([String]) cases. It can still be initialized with a string literal, with `.` representing keyPaths.
 - Array indexes can now also be pathed into using an int in the keyPath, e.g: `myArray.2.valueInArrayItem`
+- Decoding Dictionaries can now have any key that conforms to JSONKey (which String does by default). So you can for example have enums as the key in a dictionary. Just make your Enum conform to JSONKey. If it is a String RawRepresentable, conformance is supplied automatically. So now you can do: 
+`let counts: [MyEnum: Int] = try jsonDictionary.json(keyKeyPath: "counts")`
 
 Thanks to [Yonas Kolb](https://github.com/yonaskolb)
 

--- a/JSONUtilities.xcodeproj/project.pbxproj
+++ b/JSONUtilities.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		4FE3C0551C00EEE800607CC4 /* JSONDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE3C0541C00EEE800607CC4 /* JSONDecodingTests.swift */; };
 		4FF31F3B1D7CBF8C00C9CCC8 /* Dictionary+KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF31F3A1D7CBF8C00C9CCC8 /* Dictionary+KeyPathTests.swift */; };
 		CC0188FF1EB2288A00D4EA87 /* InvalidItemBehaviour.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0188FE1EB2288A00D4EA87 /* InvalidItemBehaviour.swift */; };
+		CC6A0B6C1EC5922700D64795 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6A0B6B1EC5922700D64795 /* KeyPath.swift */; };
 		CCE82AD11EAA41900035C9F1 /* InvalidItemBehaviourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE82ACF1EAA41450035C9F1 /* InvalidItemBehaviourTests.swift */; };
 		EAD4CA401D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD4CA3F1D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift */; };
 /* End PBXBuildFile section */
@@ -86,6 +87,7 @@
 		4FE3C05B1C00F05700607CC4 /* JSONFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONFiles.swift; sourceTree = "<group>"; };
 		4FF31F3A1D7CBF8C00C9CCC8 /* Dictionary+KeyPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+KeyPathTests.swift"; sourceTree = "<group>"; };
 		CC0188FE1EB2288A00D4EA87 /* InvalidItemBehaviour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvalidItemBehaviour.swift; sourceTree = "<group>"; };
+		CC6A0B6B1EC5922700D64795 /* KeyPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
 		CCE82ACF1EAA41450035C9F1 /* InvalidItemBehaviourTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvalidItemBehaviourTests.swift; sourceTree = "<group>"; };
 		EAD4CA3F1D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+JSONPrimitiveConvertible.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -172,6 +174,7 @@
 				4F037C291D1B406D0075FC5E /* JSONPrimitiveConvertible.swift */,
 				EAD4CA3F1D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift */,
 				CC0188FE1EB2288A00D4EA87 /* InvalidItemBehaviour.swift */,
+				CC6A0B6B1EC5922700D64795 /* KeyPath.swift */,
 			);
 			path = JSONUtilities;
 			sourceTree = "<group>";
@@ -387,6 +390,7 @@
 				CC0188FF1EB2288A00D4EA87 /* InvalidItemBehaviour.swift in Sources */,
 				4F037C2A1D1B406D0075FC5E /* JSONObjectConvertible.swift in Sources */,
 				EAD4CA401D894B0D001842D6 /* URL+JSONPrimitiveConvertible.swift in Sources */,
+				CC6A0B6C1EC5922700D64795 /* KeyPath.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ When decoding arrays or dictionaries an `invalidItemBehaviour` parameter can be 
 - `.value(T)` Provide an alternative value
 - `.custom((DecodingError) -> InvalidItemBehaviour)` Lets you specify the behaviour based on the specific DecodingError
 
+## KeyPath
+Each json(atKeyPath:) function takes a KeyPath. This is an enum with 2 cases:
+
+- `key(String)` - this does a single key lookup
+- `keyPath([String])` - this does a nested key lookup
+
+KeyPath can be initialized with a string literal. When doing so, if there are any `.` it will be treated as a keypath instead of a simple key.
+
+When providing keyPaths, an int allows lookup up a value in an array by index. eg: `"myArray.1"` string literal will look for the key `myArray ` and then the 2nd item if that value is an array (indices are 0 based)
+
 ## Examples of JSON loading
 
 ### From file

--- a/README.md
+++ b/README.md
@@ -60,12 +60,21 @@ e.g. if `MyClass` and `MyStruct` conform to `JSONObjectConvertible` protocol
 - `MyStruct`
 - [`MyStruct`]
 
-### Typed dictionaries with a `String` key
+### Dictionaries with a `JSONKey`
 
-- `[String: JSONRawType]`
-- `[String: JSONObjectConvertible]`
-- `[String: JSONPrimitiveConvertible]`
-- `[String: RawRepresentable]`
+- `[JSONKey: JSONRawType]`
+- `[JSONKey: JSONObjectConvertible]`
+- `[JSONKey: JSONPrimitiveConvertible]`
+- `[JSONKey: RawRepresentable]`
+
+String already conforms to JSONKey, and if you want other keys like enums just make them conform to JSONKey e.g:
+
+```
+enum MyEnum: String, JSONKey {
+	case one
+	case two
+}
+```
 
 ## InvalidItemBehaviour
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,16 @@ e.g. if `MyClass` and `MyStruct` conform to `JSONObjectConvertible` protocol
 - `[JSONKey: JSONPrimitiveConvertible]`
 - `[JSONKey: RawRepresentable]`
 
-String already conforms to JSONKey, and if you want other keys like enums just make them conform to JSONKey e.g:
+String already conforms to JSONKey. It's also easy to make enum keys by just making them conform to JSONKey which requires a `var key: String { get }`, and an `init?(rawValue: String)` which RawRepresentable already conforms to e.g:
 
 ```
 enum MyEnum: String, JSONKey {
 	case one
 	case two
+	
+	var key: String {
+		return rawValue
+	}
 }
 ```
 

--- a/Sources/JSONUtilities/DecodingError.swift
+++ b/Sources/JSONUtilities/DecodingError.swift
@@ -33,7 +33,7 @@ public struct DecodingError: Error, CustomStringConvertible, CustomDebugStringCo
 
   init(dictionary: [AnyHashable: Any], keyPath: KeyPath, expectedType: Any.Type, value: Any, array: JSONArray? = nil, reason: Reason) {
     self.dictionary = dictionary
-    self.keyPath = keyPath.string
+    self.keyPath = keyPath.key
     self.expectedType = expectedType
     self.value = value
     self.reason = reason

--- a/Sources/JSONUtilities/DecodingError.swift
+++ b/Sources/JSONUtilities/DecodingError.swift
@@ -31,7 +31,7 @@ public struct DecodingError: Error, CustomStringConvertible, CustomDebugStringCo
   /// the value that caused the error
   public let value: Any
 
-  init(dictionary: [AnyHashable: Any], keyPath: StringProtocol, expectedType: Any.Type, value: Any, array: JSONArray? = nil, reason: Reason) {
+  init(dictionary: [AnyHashable: Any], keyPath: KeyPath, expectedType: Any.Type, value: Any, array: JSONArray? = nil, reason: Reason) {
     self.dictionary = dictionary
     self.keyPath = keyPath.string
     self.expectedType = expectedType

--- a/Sources/JSONUtilities/Deprecations.swift
+++ b/Sources/JSONUtilities/Deprecations.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public extension Dictionary where Key: StringProtocol, Value: Any {
+public extension Dictionary where Key: JSONKey, Value: Any {
 
   @available(*, deprecated:3.0.0, renamed: "from(filename:)")
   public static func fromFile(_ filename: String) throws -> JSONDictionary {
@@ -22,126 +22,126 @@ public extension Dictionary where Key: StringProtocol, Value: Any {
 
 }
 
-public extension Dictionary where Key: StringProtocol {
+public extension Dictionary where Key: JSONKey {
 
   // MARK: JSONRawType type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) throws -> ReturnType {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) -> ReturnType? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: [JSONRawType] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) throws -> [ReturnType] {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) -> [ReturnType]? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: [String: Any] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) throws -> JSONDictionary {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) -> JSONDictionary? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: [[String: Any]] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) throws -> [JSONDictionary] {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) -> [JSONDictionary]? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: Decodable types
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) throws -> ReturnType {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) -> ReturnType? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: [Decodable] types
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) throws -> [ReturnType] {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) -> [ReturnType]? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: RawRepresentable type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) throws -> ReturnType where ReturnType.RawValue:JSONRawType {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) -> ReturnType? where ReturnType.RawValue:JSONRawType {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: [RawRepresentable] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) throws -> [ReturnType] where ReturnType.RawValue:JSONRawType {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) -> [ReturnType]? where ReturnType.RawValue:JSONRawType {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: JSONPrimitiveConvertible type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) throws -> T {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) -> T? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
   // MARK: [JSONPrimitiveConvertible] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) throws -> [T] {
-    return try json(atKeyPath: .key(key.string))
+    return try json(atKeyPath: .key(key.key))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) -> [T]? {
-    return json(atKeyPath: .key(key.string))
+    return json(atKeyPath: .key(key.key))
   }
 
 }

--- a/Sources/JSONUtilities/Deprecations.swift
+++ b/Sources/JSONUtilities/Deprecations.swift
@@ -28,120 +28,120 @@ public extension Dictionary where Key: StringProtocol {
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) throws -> ReturnType {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) -> ReturnType? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: [JSONRawType] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) throws -> [ReturnType] {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONRawType>(_ key: Key) -> [ReturnType]? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: [String: Any] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) throws -> JSONDictionary {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) -> JSONDictionary? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: [[String: Any]] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) throws -> [JSONDictionary] {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey(_ key: Key) -> [JSONDictionary]? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: Decodable types
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) throws -> ReturnType {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) -> ReturnType? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: [Decodable] types
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) throws -> [ReturnType] {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: JSONObjectConvertible>(_ key: Key) -> [ReturnType]? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: RawRepresentable type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) throws -> ReturnType where ReturnType.RawValue:JSONRawType {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) -> ReturnType? where ReturnType.RawValue:JSONRawType {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: [RawRepresentable] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) throws -> [ReturnType] where ReturnType.RawValue:JSONRawType {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<ReturnType: RawRepresentable>(_ key: Key) -> [ReturnType]? where ReturnType.RawValue:JSONRawType {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: JSONPrimitiveConvertible type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) throws -> T {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) -> T? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
   // MARK: [JSONPrimitiveConvertible] type
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) throws -> [T] {
-    return try json(atKeyPath: key)
+    return try json(atKeyPath: .key(key.string))
   }
 
   @available(*, deprecated:3.0.0, renamed: "json(atKeyPath:)")
   public func jsonKey<T: JSONPrimitiveConvertible>(_ key: Key) -> [T]? {
-    return json(atKeyPath: key)
+    return json(atKeyPath: .key(key.string))
   }
 
 }

--- a/Sources/JSONUtilities/Dictionary+JSONKey.swift
+++ b/Sources/JSONUtilities/Dictionary+JSONKey.swift
@@ -18,7 +18,6 @@ extension Bool : JSONRawType {}
 
 // Simple protocol used to extend a JSONDictionary
 public protocol StringProtocol {
-  func components(separatedBy: String) -> [String]
   var string: String { get }
 }
 extension String: StringProtocol {
@@ -32,109 +31,109 @@ extension Dictionary where Key: StringProtocol {
   // MARK: JSONRawType type
 
   /// Decode a mandatory JSON raw type
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key) throws -> T {
+  public func json<T: JSONRawType>(atKeyPath keyPath: KeyPath) throws -> T {
     return try getValue(atKeyPath: keyPath)
   }
 
   /// Decode an optional JSON raw type
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key) -> T? {
+  public func json<T: JSONRawType>(atKeyPath keyPath: KeyPath) -> T? {
     return try? json(atKeyPath: keyPath)
   }
 
   // MARK: [JSONRawType] type
 
   /// Decode an Array of mandatory JSON raw types
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
+  public func json<T: JSONRawType>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour, decode: getValue)
   }
 
   /// Decode an Array of optional JSON raw types
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
+  public func json<T: JSONRawType>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
     return try? self.json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
   // MARK: [String: Any] type
 
   /// Decodes as a raw Dictionary with a mandatory key
-  public func json(atKeyPath keyPath: Key) throws -> JSONDictionary {
+  public func json(atKeyPath keyPath: KeyPath) throws -> JSONDictionary {
     return try getValue(atKeyPath: keyPath)
   }
 
   /// Decodes as a raw dictionary with an optional key
-  public func json(atKeyPath keyPath: Key) -> JSONDictionary? {
+  public func json(atKeyPath keyPath: KeyPath) -> JSONDictionary? {
     return self[keyPath: keyPath] as? JSONDictionary
   }
 
   // MARK: [[String: Any]] type
 
   /// Decodes as a raw dictionary array with a mandatory key
-  public func json(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<JSONDictionary> = .remove) throws -> [JSONDictionary] {
+  public func json(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<JSONDictionary> = .remove) throws -> [JSONDictionary] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour, decode: getValue)
   }
 
   /// Decodes as a raw ictionary array with an optional key
-  public func json(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<JSONDictionary> = .remove) -> [JSONDictionary]? {
+  public func json(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<JSONDictionary> = .remove) -> [JSONDictionary]? {
     return try? self.json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
   // MARK: [String: JSONObjectConvertible] type
 
   /// Decodes a mandatory dictionary
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
     return try decodeDictionary(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { jsonDictionary, key in
       return try jsonDictionary.json(atKeyPath: key) as T
     }
   }
 
   /// Decodes an optional dictionary
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) as [String: T]
   }
 
   // MARK: [String: JSONRawType] type
 
   /// Decodes a mandatory dictionary
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
+  public func json<T: JSONRawType>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
     return try decodeDictionary(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { jsonDictionary, key in
       return try jsonDictionary.json(atKeyPath: key) as T
     }
   }
 
   /// Decodes an optional dictionary
-  public func json<T: JSONRawType>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
+  public func json<T: JSONRawType>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) as [String: T]
   }
 
   // MARK: [String: JSONPrimitiveConvertible] type
 
   /// Decodes a mandatory dictionary
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] {
     return try decodeDictionary(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { jsonDictionary, key in
       return try jsonDictionary.json(atKeyPath: key) as T
     }
   }
 
   /// Decodes an optional dictionary
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) as [String: T]
   }
 
   // MARK: Decodable types
 
   /// Decode a mandatory Decodable object
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key) throws -> T {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: KeyPath) throws -> T {
     return try T(jsonDictionary: JSONDictionaryForKey(atKeyPath: keyPath))
   }
 
   /// Decode an optional Decodable object
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key) -> T? {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: KeyPath) -> T? {
     return try? T(jsonDictionary: JSONDictionaryForKey(atKeyPath: keyPath))
   }
 
   // MARK: [Decodable] types
 
   /// Decode an Array of mandatory Decodable objects
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { keyPath, jsonArray, value in
       let jsonDictionary: JSONDictionary = try getValue(atKeyPath: keyPath, array: jsonArray, value: value)
       return try T(jsonDictionary: jsonDictionary)
@@ -142,14 +141,14 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Decode an Array of optional Decodable objects
-  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
+  public func json<T: JSONObjectConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
   // MARK: RawRepresentable type
 
   /// Decode a mandatory RawRepresentable
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key) throws -> T where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: KeyPath) throws -> T where T.RawValue:JSONRawType {
     let rawValue: T.RawValue = try getValue(atKeyPath: keyPath)
 
     guard let value = T(rawValue:rawValue) else {
@@ -160,14 +159,14 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Decode an optional RawRepresentable
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key) -> T? where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: KeyPath) -> T? where T.RawValue:JSONRawType {
     return try? json(atKeyPath: keyPath)
   }
 
   // MARK: [RawRepresentable] type
 
   /// Decode an array of custom RawRepresentable types with a mandatory key
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] where T.RawValue:JSONRawType {
 
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { keyPath, jsonArray, value in
       let rawValue: T.RawValue = try getValue(atKeyPath: keyPath, array: jsonArray, value: value)
@@ -180,14 +179,14 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Optionally decode an array of RawRepresentable types with a mandatory key
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? where T.RawValue:JSONRawType {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
   // MARK: [String: RawRepresentable] type
 
   /// Decode a dictionary of custom RawRepresentable types with a mandatory key
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [String: T] where T.RawValue:JSONRawType {
     return try decodeDictionary(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { jsonDictionary, key in
       let rawValue: T.RawValue = try jsonDictionary.getValue(atKeyPath: key)
 
@@ -199,14 +198,14 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Optionally decode a dictionary of RawRepresentable types with a mandatory key
-  public func json<T: RawRepresentable>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? where T.RawValue:JSONRawType {
+  public func json<T: RawRepresentable>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [String: T]? where T.RawValue:JSONRawType {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
   // MARK: JSONPrimitiveConvertible type
 
   /// Decode a custom raw types with a mandatory key
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key) throws -> T {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: KeyPath) throws -> T {
     let jsonValue: T.JSONType = try getValue(atKeyPath: keyPath)
 
     guard let transformedValue = T.from(jsonValue: jsonValue) else {
@@ -217,14 +216,14 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Optionally decode a custom raw types with a mandatory key
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key) -> T? {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: KeyPath) -> T? {
     return try? json(atKeyPath: keyPath)
   }
 
   // MARK: [JSONPrimitiveConvertible] type
 
   /// Decode an array of custom raw types with a mandatory key
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
     return try decodeArray(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour) { keyPath, jsonArray, value in
       let jsonValue: T.JSONType = try getValue(atKeyPath: keyPath, array: jsonArray, value: value)
 
@@ -236,30 +235,30 @@ extension Dictionary where Key: StringProtocol {
   }
 
   /// Optionally decode an array custom raw types with a mandatory key
-  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
+  public func json<T: JSONPrimitiveConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) -> [T]? {
     return try? json(atKeyPath: keyPath, invalidItemBehaviour: invalidItemBehaviour)
   }
 
   // MARK: JSONDictionary and JSONArray creation
 
-  fileprivate func JSONDictionaryForKey(atKeyPath keyPath: Key) throws -> JSONDictionary {
+  fileprivate func JSONDictionaryForKey(atKeyPath keyPath: KeyPath) throws -> JSONDictionary {
     return try getValue(atKeyPath: keyPath)
   }
 
-  fileprivate func JSONArrayForKey(atKeyPath keyPath: Key) throws -> JSONArray {
+  fileprivate func JSONArrayForKey(atKeyPath keyPath: KeyPath) throws -> JSONArray {
     return try getValue(atKeyPath: keyPath)
   }
 
   // MARK: Value decoding
 
-  fileprivate func getValue<A, B>(atKeyPath keyPath: Key, array: [A], value: A) throws -> B {
+  fileprivate func getValue<A, B>(atKeyPath keyPath: KeyPath, array: [A], value: A) throws -> B {
     guard let typedValue = value as? B else {
       throw DecodingError(dictionary: self, keyPath: keyPath, expectedType: B.self, value: value, array: array, reason: .incorrectType)
     }
     return typedValue
   }
 
-  fileprivate func getValue<T>(atKeyPath keyPath: Key) throws -> T {
+  fileprivate func getValue<T>(atKeyPath keyPath: KeyPath) throws -> T {
     guard let value = self[keyPath: keyPath] else {
       throw DecodingError(dictionary: self, keyPath: keyPath, expectedType: T.self, value: "", reason: .keyNotFound)
     }
@@ -271,12 +270,12 @@ extension Dictionary where Key: StringProtocol {
 
   // MARK: Dictionary decoding
 
-  fileprivate func decodeDictionary<T>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove, decode: (JSONDictionary, String) throws -> T) throws -> [String: T] {
+  fileprivate func decodeDictionary<T>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove, decode: (JSONDictionary, KeyPath) throws -> T) throws -> [String: T] {
     let jsonDictionary: JSONDictionary = try json(atKeyPath: keyPath)
 
     var dictionary: [String: T] = [:]
     for (key, _) in jsonDictionary {
-      if let item = try invalidItemBehaviour.decodeItem(decode: { try decode(jsonDictionary, key) }) {
+      if let item = try invalidItemBehaviour.decodeItem(decode: { try decode(jsonDictionary, KeyPath(key)) }) {
           dictionary[key] = item
       }
     }
@@ -287,7 +286,7 @@ extension Dictionary where Key: StringProtocol {
   // MARK: Array decoding
 
   //swiftlint:disable:next large_tuple
-  fileprivate func decodeArray<T>(atKeyPath keyPath: Key, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove, decode: (Key, JSONArray, Any) throws -> T) throws -> [T] {
+  fileprivate func decodeArray<T>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove, decode: (KeyPath, JSONArray, Any) throws -> T) throws -> [T] {
     let jsonArray = try JSONArrayForKey(atKeyPath: keyPath)
 
     return try jsonArray.flatMap { value in

--- a/Sources/JSONUtilities/Dictionary+KeyPath.swift
+++ b/Sources/JSONUtilities/Dictionary+KeyPath.swift
@@ -15,19 +15,11 @@ extension Dictionary {
   /// - parameter keyPath: A string of keys separated by dots
   ///
   /// - returns: Optionally returns a generic value for this keyPath or nil
-  subscript(keyPath keyPath: StringProtocol) -> Any? {
-    var keys = keyPath.components(separatedBy: ".")
-    guard let firstKey = keys.first as? Key,
-          let value = self[firstKey]
-      else { return nil }
-
-    keys.removeFirst()
-
-    if !keys.isEmpty, let subDictionary = value as? [Key : Any] {
-      let rejoined = keys.joined(separator: ".")
-      return subDictionary[keyPath: rejoined]
+  subscript(keyPath keyPath: KeyPath) -> Any? {
+    guard let dictionary = self as? JSONDictionary else {
+      return nil
     }
-    return value
+    return keyPath.getValue(dictionary: dictionary)
   }
 
 }

--- a/Sources/JSONUtilities/JSONFileLoading.swift
+++ b/Sources/JSONUtilities/JSONFileLoading.swift
@@ -25,7 +25,7 @@ public enum JSONUtilsError: Error {
   case fileNotAJSONDictionary
 }
 
-public extension Dictionary where Key: StringProtocol, Value: Any {
+public extension Dictionary where Key: JSONKey, Value: Any {
 
   /**
    Load a JSONDictionary from a file

--- a/Sources/JSONUtilities/KeyPath.swift
+++ b/Sources/JSONUtilities/KeyPath.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-public enum KeyPath {
+public enum KeyPath: JSONKey {
   case key(String)
   case keyPath([String])
 
-  public init(_ keyPath: String) {
-    var parts = keyPath.components(separatedBy: ".")
+  public init(rawValue: String) {
+    var parts = rawValue.components(separatedBy: ".")
 
     //removes trailing .
     if parts.count > 1, let last = parts.last, last.isEmpty {
@@ -23,11 +23,11 @@ public enum KeyPath {
     if parts.count > 1 {
       self = .keyPath(parts)
     } else {
-      self = .key(keyPath)
+      self = .key(rawValue)
     }
   }
 
-  public var string: String {
+  public var key: String {
     switch self {
       case .key(let key): return key
       case .keyPath(let keys): return keys.joined(separator: ".")
@@ -89,14 +89,14 @@ extension KeyPath: ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = String
 
   public init(stringLiteral value: KeyPath.StringLiteralType) {
-    self = KeyPath(value)
+    self = KeyPath(rawValue: value)
   }
 
   public init(extendedGraphemeClusterLiteral value: KeyPath.ExtendedGraphemeClusterLiteralType) {
-    self = KeyPath(value)
+    self = KeyPath(rawValue: value)
   }
 
   public init(unicodeScalarLiteral value: KeyPath.UnicodeScalarLiteralType) {
-    self = KeyPath(value)
+    self = KeyPath(rawValue: value)
   }
 }

--- a/Sources/JSONUtilities/KeyPath.swift
+++ b/Sources/JSONUtilities/KeyPath.swift
@@ -1,0 +1,102 @@
+//
+//  KeyType.swift
+//  JSONUtilities
+//
+//  Created by Yonas Kolb on 12/5/17.
+//  Copyright © 2017 Luciano Marisi. All rights reserved.
+//
+
+import Foundation
+
+public enum KeyPath {
+  case key(String)
+  case keyPath([String])
+
+  public init(_ keyPath: String) {
+    var parts = keyPath.components(separatedBy: ".")
+
+    //removes trailing .
+    if parts.count > 1, let last = parts.last, last.isEmpty {
+      _ = parts.popLast()
+    }
+
+    if parts.count > 1 {
+      self = .keyPath(parts)
+    } else {
+      self = .key(keyPath)
+    }
+  }
+
+  public var string: String {
+    switch self {
+      case .key(let key): return key
+      case .keyPath(let keys): return keys.joined(separator: ".")
+    }
+  }
+
+  func getValue(dictionary: JSONDictionary) -> Any? {
+
+    switch self {
+    case .key(let key):
+      return dictionary[key]
+    case .keyPath(let keys):
+      guard let firstKey = keys.first,
+      let value = dictionary[firstKey] else {
+        return nil
+      }
+      var newKeys = keys
+      newKeys.removeFirst()
+      if newKeys.isEmpty {
+        return value
+      } else {
+        guard let secondKey = newKeys.first else {
+          return nil
+        }
+
+        // index into array
+        if let index = Int(secondKey), index >= 0,
+          let array = value as? JSONArray {
+          guard index < array.count else {
+            // index out of bounds
+            return nil
+          }
+          newKeys.removeFirst()
+          let arrayValue = array[index]
+          if newKeys.isEmpty {
+            return arrayValue
+          }
+          guard let dictionary = arrayValue as? JSONDictionary else {
+            // array value isn't dictionary
+            return nil
+          }
+          return KeyPath.keyPath(newKeys).getValue(dictionary: dictionary)
+        }
+
+        guard let dictionary = value as? JSONDictionary else {
+          // second key path isn't a dictionary
+          return nil
+        }
+        return KeyPath.keyPath(newKeys).getValue(dictionary: dictionary)
+      }
+    }
+  }
+}
+
+extension KeyPath: ExpressibleByStringLiteral {
+
+  public typealias StringLiteralType = String
+  public typealias ExtendedGraphemeClusterLiteralType = String
+  public typealias UnicodeScalarLiteralType = String
+
+  public init(stringLiteral value: KeyPath.StringLiteralType) {
+    self = KeyPath(value)
+  }
+
+  public init(extendedGraphemeClusterLiteral value: KeyPath.ExtendedGraphemeClusterLiteralType) {
+    self = KeyPath(value)
+  }
+
+  public init(unicodeScalarLiteral value: KeyPath.UnicodeScalarLiteralType) {
+    self = KeyPath(value)
+  }
+}

--- a/Tests/JSONUtilitiesTests/Dictionary+KeyPathTests.swift
+++ b/Tests/JSONUtilitiesTests/Dictionary+KeyPathTests.swift
@@ -41,6 +41,38 @@ class Dictionary_KeyPathTests: XCTestCase {
     XCTAssertEqual(calculatedValue, expectedValue)
   }
 
+  func testAccessArrayIndex() {
+    let expectedValue = "value"
+    let dictionary = [
+      "root_key": [
+          "incorrectValue1",
+          expectedValue,
+          "incorrectValue2"
+      ]
+    ]
+    guard let calculatedValue = dictionary[keyPath: "root_key.1"] as? String else {
+      XCTFail(#function)
+      return
+    }
+    XCTAssertEqual(calculatedValue, expectedValue)
+  }
+
+  func testAccessArrayIndexAndThenDictioanry() {
+    let expectedValue = "value"
+    let dictionary = [
+      "root_key": [
+        ["incorrectDictionary1": "incorrectValue"],
+        ["firstLevelKey": expectedValue],
+        ["incorrectDictionary1": "incorrectValue"]
+      ]
+    ]
+    guard let calculatedValue = dictionary[keyPath: "root_key.1.firstLevelKey"] as? String else {
+      XCTFail(#function)
+      return
+    }
+    XCTAssertEqual(calculatedValue, expectedValue)
+  }
+
   func testAccessRepeatedKey_InSequence_OneLevelDeep() {
     let expectedValue = "value"
     let dictionary = [
@@ -49,6 +81,22 @@ class Dictionary_KeyPathTests: XCTestCase {
       ]
     ]
     guard let calculatedValue = dictionary[keyPath: "root_key.root_key"] as? String else {
+      XCTFail(#function)
+      return
+    }
+    XCTAssertEqual(calculatedValue, expectedValue)
+  }
+
+  func testAccessInDictionary_withIntKey() {
+    let expectedValue = "value"
+    let dictionary = [
+      "root_key": [
+        "1": [
+          "root_key": expectedValue
+        ]
+      ]
+    ]
+    guard let calculatedValue = dictionary[keyPath: "root_key.1.root_key"] as? String else {
       XCTFail(#function)
       return
     }

--- a/Tests/JSONUtilitiesTests/Helpers/XCTestCase+Additions.swift
+++ b/Tests/JSONUtilitiesTests/Helpers/XCTestCase+Additions.swift
@@ -33,7 +33,7 @@ extension XCTestCase {
         return
       }
       XCTAssertTrue(error.reason == reason, "DecodingError failed because of \"\(error.reason)\" but was supposed to fail for \"\(reason)\"")
-      XCTAssertTrue(error.keyPath == keyPath.string, "DecodingError failed at keyPath \"\(error.keyPath)\", but was supposed to fail at \"\(keyPath)\"")
+      XCTAssertTrue(error.keyPath == keyPath.key, "DecodingError failed at keyPath \"\(error.keyPath)\", but was supposed to fail at \"\(keyPath)\"")
     }
   }
 }

--- a/Tests/JSONUtilitiesTests/Helpers/XCTestCase+Additions.swift
+++ b/Tests/JSONUtilitiesTests/Helpers/XCTestCase+Additions.swift
@@ -23,7 +23,7 @@ extension XCTestCase {
     }
   }
 
-  func expectDecodingError(reason: DecodingError.Reason, keyPath: String, decode: () throws -> Void) {
+  func expectDecodingError(reason: DecodingError.Reason, keyPath: KeyPath, decode: () throws -> Void) {
     do {
       try decode()
       XCTFail("Decoding was supposed to throw \"\(reason)\" error")
@@ -33,7 +33,7 @@ extension XCTestCase {
         return
       }
       XCTAssertTrue(error.reason == reason, "DecodingError failed because of \"\(error.reason)\" but was supposed to fail for \"\(reason)\"")
-      XCTAssertTrue(error.keyPath == keyPath, "DecodingError failed at keyPath \"\(error.keyPath)\", but was supposed to fail at \"\(keyPath)\"")
+      XCTAssertTrue(error.keyPath == keyPath.string, "DecodingError failed at keyPath \"\(error.keyPath)\", but was supposed to fail at \"\(keyPath)\"")
     }
   }
 }

--- a/Tests/JSONUtilitiesTests/InlineDecodingTests.swift
+++ b/Tests/JSONUtilitiesTests/InlineDecodingTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import JSONUtilities
 
-private let randomKey = "aaaaaaa"
+private let randomKey: KeyPath = "aaaaaaa"
 
 class InlineDecodingTests: XCTestCase {
 

--- a/Tests/JSONUtilitiesTests/InlineDecodingTests.swift
+++ b/Tests/JSONUtilitiesTests/InlineDecodingTests.swift
@@ -130,6 +130,24 @@ class InlineDecodingTests: XCTestCase {
     XCTAssertNil(decodedEnums)
   }
 
+  func test_decodingStringDictionary_withEnumKey() {
+    let dictionary: JSONDictionary = ["enums": ["one": "two", "two": "one", "value3": "two"]]
+
+    let decodedEnums: [MockParent.MockEnum: String]? = dictionary.json(atKeyPath: "enums")
+
+    let expectedEnums: [MockParent.MockEnum: String] = [.one: "two", .two: "one"]
+    XCTAssertEqual(decodedEnums!, expectedEnums)
+  }
+
+  func test_decodingEnumDictionary_withEnumKey() {
+    let dictionary: JSONDictionary = ["enums": ["one": "two", "two": "one", "value3": "two"]]
+
+    let decodedEnums: [MockParent.MockEnum: MockParent.MockEnum]? = dictionary.json(atKeyPath: "enums")
+
+    let expectedEnums: [MockParent.MockEnum: MockParent.MockEnum] = [.one: .two, .two: .one]
+    XCTAssertEqual(decodedEnums!, expectedEnums)
+  }
+
   func testDecodingOfJSONDictionaryArray() {
 
     let expectedValue: [JSONDictionary] = [["key1": "value1"], ["key2": "value2"]]

--- a/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
+++ b/Tests/JSONUtilitiesTests/InvalidItemBehaviourTests.swift
@@ -9,11 +9,10 @@
 import XCTest
 @testable import JSONUtilities
 
-private let randomKey = "aaaaaaa"
-
 class InvalidItemBehaviourTests: XCTestCase {
 
-  let key = "key"
+  private let randomKey: KeyPath = "aaaaaaa"
+  private let key: KeyPath = "key"
 
   let dictionaryString = [
     "key": [

--- a/Tests/JSONUtilitiesTests/JSONPrimitiveConvertibleTests.swift
+++ b/Tests/JSONUtilitiesTests/JSONPrimitiveConvertibleTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import JSONUtilities
 
-private let invalidKey = "invalidKey"
+private let invalidKey: KeyPath = "invalidKey"
 
 class JSONPrimitiveConvertibleTests: XCTestCase {
 

--- a/Tests/JSONUtilitiesTests/Mocks/MockChild.swift
+++ b/Tests/JSONUtilitiesTests/Mocks/MockChild.swift
@@ -25,6 +25,13 @@ extension MockChild : JSONObjectConvertible {
   }
 }
 
+// for [MockParent.MockEnum: SomeType] decoding support
+extension MockParent.MockEnum: JSONKey {
+  var key: String {
+    return rawValue
+  }
+}
+
 // MARK: Extensions necessary for testing
 
 extension MockChild : Equatable {}

--- a/Tests/JSONUtilitiesTests/Mocks/MockParent.swift
+++ b/Tests/JSONUtilitiesTests/Mocks/MockParent.swift
@@ -9,7 +9,7 @@
 import Foundation
 @testable import JSONUtilities
 
-private let randomKey = "asdfghj"
+private let randomKey: KeyPath = "asdfghj"
 
 struct MockParent {
 


### PR DESCRIPTION
This changes keyPath to a KeyPath enum, with .key(String) and .keyPath([String]) cases. It can still be initialized with a string literal, with `.` representing keyPaths.

This fixes #4 by simply specifying `keyPath: .key("value.that.has.dots.but.isnt.a.key.path")`

This also adds the ability for keyPaths to access Array indexes e.g: `myArray.2.valueInArrayItem`

Thoughts? I'm open to name changes on any of this. Not sure about the enum case names